### PR TITLE
fixed multithreading

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -1,8 +1,10 @@
 import tensorflow as tf
 from multiprocessing import Condition, Lock, Process, Manager
 import random
+#from utils import train_ids, test_ids, get_data
 from utils import train_ids, test_ids, get_data
 import pdb
+
 
 class DataLoader:
     """ Class for loading data
@@ -48,10 +50,12 @@ class DataLoader:
                 random.shuffle(self.data_ids)
             self.batch_lock.release()
             
+            data = get_data(image_ids)
+
             self.cv_full.acquire()
             if len(self.data_load_queue) > self.data_load_capacity:
                 self.cv_full.wait()
-            self.data_load_queue.append(get_data(image_ids))
+            self.data_load_queue.append(data)
             self.cv_empty.notify()
             self.cv_full.release()
 


### PR DESCRIPTION
Previously the bottleneck in multi-threading data loader - get_data() - is inside a lock that is shared among all threads. As a result, only one thread can load data at a time. I moved get_data() out of the lock while kept "pushing the loaded data into the queue" inside the lock. This way each thread is still safe but will not lock each other.